### PR TITLE
Remove exposed ports from nginx service

### DIFF
--- a/picbox.sh
+++ b/picbox.sh
@@ -270,9 +270,6 @@ services:
   nginx:
     image: nginx:alpine
     container_name: nginx
-    ports:
-      - "443:443"
-      - "3080:3080"
     volumes:
       - ./nginx/certs:/etc/nginx/certs:ro
       - ./nginx/conf.d:/etc/nginx/conf.d:ro


### PR DESCRIPTION
The ports 443 and 3080 are no longer exposed for the nginx service in the configuration. This may be for security reasons or to rely on internal networking instead.